### PR TITLE
Add support for stack, use stack in travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cabal.sandbox.config
 tmp
 *.log
 data
+.stack-work/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,31 @@
-language: haskell
+# Use new container infrastructure to enable caching
+sudo: false
+
+  # Choose a lightweight base image; we provide our own build tools.
+language: c
+
+  # GHC depends on GMP. You can add other dependencies here as well.
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.6.0/stack-0.1.6.0-linux-x86_64.tar.gz | tar xz -C ~/.local/bin
+- cp ~/.local/bin/stack-0.1.6.0-linux-x86_64/stack ~/.local/bin/
+
+# This line does all of the work: installs GHC if necessary, build the library,
+# executables, and test suites, and runs the test suites. --no-terminal works
+# around some quirks in Travis's terminal implementation.
+script:
+- stack setup
+- stack build --no-terminal --install-ghc
+- stack test --coverage
+
+  # Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack

--- a/hadron.cabal
+++ b/hadron.cabal
@@ -59,7 +59,7 @@ library
                        hslogger                     >= 1.2 && < 1.3,
                        katip,
                        lcs,
-                       lens                         >= 4.0 && < 4.10,
+                       lens                         >= 4.0 && < 4.14,
                        mmorph,
                        mtl,
                        old-locale,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,15 @@
+flags: {}
+packages:
+- location:
+    git: https://github.com/Soostone/katip.git
+    commit: c3592c9019b99813e9a25404bd290f677f2153ce
+  subdirs:
+  - katip
+- '.'
+extra-deps:
+- attoparsec-conduit-1.1.0
+- blaze-builder-conduit-1.1.0
+- lcs-0.2
+- string-conv-0.1
+- zlib-conduit-1.1.0
+resolver: lts-2.22


### PR DESCRIPTION
@ozataman Do you have any comments?
I added support for stack and travis now uses it and [works](https://travis-ci.org/juanpaucar/juanpaucar/hadron/builds/86115888).
Right now it only works with GHC 7.8. I'm gonna add support for GHC 7.10 when the owner of the [lcs](https://hackage.haskell.org/package/lcs) makes me a maintainer, although stack can use sources from private repos and I have already added support for GHC 7.10 in my own fork [here](https://github.com/juanpaucar/lcs). But in the meantime I think stack support is useful.